### PR TITLE
Don't quarantine chromium

### DIFF
--- a/Brewfile.example
+++ b/Brewfile.example
@@ -45,7 +45,7 @@ cask "google-chrome"
 cask "google-chrome-canary"
 
 # chromium is mandatory for testing purposes
-cask "chromium"
+cask "chromium", args: {'no-quarantine': true}
 
 # IDE/Editors
 brew "vim"


### PR DESCRIPTION
At least on my M3, chromium was reported as »broken« when quarantined. Edit: https://docs.zeit.de/friedbert/coding/testing/selenium_tests.html recommends the same.